### PR TITLE
Allow empty channel for API

### DIFF
--- a/functions/rest_api.php
+++ b/functions/rest_api.php
@@ -6,14 +6,14 @@
  * @param string $to filter by topic
  * @return array
  */
-function fcm_rest_api_messages ( $language, $to ) {
+function fcm_rest_api_messages ( $language, $to = Null ) {
     $fcmdb = New FirebaseNotificationsDatabase();
     $newer_than = date('Y-m-d G:i:s', time() - ( 2 * 7 * 24 * 3600 ));
     $messages = $fcmdb->messages_by_language( $lang = $language, $amount = 0, $timestamp = $newer_than );
     $return = array();
     $n = 0;
     foreach ( $messages as $message ) {
-        if ( $message['answer'] != Null And $message['request']['to'] == "/topics/" . $to ) {
+        if ( $message['answer'] != Null && ( $to === Null || $message['request']['to'] == "/topics/" . $to ) ) {
             $return[$n]['timestap'] = $message['timestamp'];
             $return[$n]['title'] = $message['request']['notification']['title'];
             $return[$n]['message'] = $message['request']['notification']['body'];


### PR DESCRIPTION
* If there is no $to parameter in the api, get messages from
  all channels in the selected language.